### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -12,6 +12,8 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     services:
       # Start your API service (adjust based on your setup)


### PR DESCRIPTION
Potential fix for [https://github.com/MetroStar/comet-api/security/code-scanning/1](https://github.com/MetroStar/comet-api/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly specify the minimal required permissions for the GITHUB_TOKEN. Since the workflow needs to push changes to the repository, it requires `contents: write`. The `permissions` block can be added at the top level of the workflow (applies to all jobs) or at the job level (applies only to the specific job). In this case, since there is only one job, adding it at the job level is sufficient and clear. You should add the following block under the `update-docs:` job definition (after `runs-on: ubuntu-latest`):

```yaml
permissions:
  contents: write
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
