### PR TITLE
Enhance and Simplify App Settings

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -10,10 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DATABASE_URL: ${{ vars.DATABASE_URL }}
-  OIDC_CONFIG_URL: ${{ vars.OIDC_CONFIG_URL }}
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,5 @@ COPY . .
 RUN pip install .
 
 COPY ./app /code/app
-COPY ./.env /code/.env
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ pip install .
 pip install -e ".[dev]"
 ```
 
-4. To prepare your environment, add a file called `.env` to the `comet-api` directory. Copy and paste the template below and replace the placeholder values with your own:
+4. To override default environment variables, add a file called `.env` to the `comet-api` directory and update as needed (optional):
 
 ```
-DATABASE_URL=[SOME_URL] # Ex: 'sqlite:///./db.sqlite3'
+DATABASE_URL=[SOME_URL] # Ex: 'postgresql://username:password@localhost:5432/database_name'
 OIDC_CONFIG_URL=[SOME_URL] # Ex: 'https://token.actions.githubusercontent.com/.well-known/openid-configuration'
 ```
 

--- a/app/config.py
+++ b/app/config.py
@@ -4,8 +4,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env")
 
-    DATABASE_URL: str
-    OIDC_CONFIG_URL: str
+    DATABASE_URL: str | None = "sqlite:///./db.sqlite3"
+    OIDC_CONFIG_URL: str | None = None
 
 
 settings = Settings()

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env")
 
-    DATABASE_URL: str | None = "sqlite:///./db.sqlite3"
+    DATABASE_URL: str = "sqlite:///./db.sqlite3"
     OIDC_CONFIG_URL: str | None = None
 
 


### PR DESCRIPTION
The current setup pushes the use of a .env for managing env variables, which can be confusing and doesn't scale well. In order to simplify this, the config should be updated with default values as well as optional values where possible.

## Description

- Updated app settings with default DATABASE_URL
- Updated app settings to make OIDC_CONFIG_URL optional
- Updated Readme to make .env optional and only needed for local overrides
- Updated Dockerfile to remove explicit copy of .env
- Updated workflow to remove vars as no longer needed

## Related Issue

N/A

## Motivation and Context

- Simplifies the process of getting up and running
- Better supports CI/CD automation where environment variables are more likely to be set in a pipeline

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
